### PR TITLE
Update grading for exam questions

### DIFF
--- a/canvas/templates/canvas/course_events_snippet.html
+++ b/canvas/templates/canvas/course_events_snippet.html
@@ -21,7 +21,11 @@
             <td>{{ event.name }}</td>
             <td>{{ event.start_date }}</td>
             <td>{{ event.end_date }}</td>
-            <td>{{ event|total_event_grade:request.user }}</td>
+            {% if event.is_exam_and_open %}
+                <td>Not Available Yet</td>
+            {% else %}
+                <td>{{ event|total_event_grade:request.user }}</td>
+            {% endif %}
             <td>
                 {% is_allowed_to_open_event event request.user as allowed_to_open %}
                 {% is_allowed_to_edit_event  event request.user as allowed_to_edit %}

--- a/canvas/templates/canvas/problem_set_snippet.html
+++ b/canvas/templates/canvas/problem_set_snippet.html
@@ -20,7 +20,8 @@
     </thead>
     <tbody>
     {% for key, uqj in uqjs.items %}
-        <tr class="{{ uqj.status_class }}">
+        {% row_class uqj event as row_class_name %}
+        <tr class="{{ row_class_name }}">
             <th scope="row">{{ forloop.counter }}</th>
             <td>{{ uqj.question.category.parent }}</td>
             <td>{{ uqj.question.category.name }}</td>

--- a/canvas/templatetags/canvas.py
+++ b/canvas/templatetags/canvas.py
@@ -57,3 +57,12 @@ def exam_question_status(event, uqj):
         return "Submitted"
     else:
         return "Not Submitted"
+
+
+# TODO: confirm if the colours should be added after exam is closed
+@register.simple_tag
+def row_class(uqj, event):
+    if isinstance(event, Event) and event.is_exam_and_open():
+        return ""
+    else:
+        return uqj.status_class

--- a/canvas/templatetags/canvas.py
+++ b/canvas/templatetags/canvas.py
@@ -59,10 +59,9 @@ def exam_question_status(event, uqj):
         return "Not Submitted"
 
 
-# TODO: confirm if the colours should be added after exam is closed
 @register.simple_tag
 def row_class(uqj, event):
-    if isinstance(event, Event) and event.is_exam_and_open():
+    if isinstance(event, Event) and event.is_exam:
         return ""
     else:
         return uqj.status_class

--- a/course/models/models.py
+++ b/course/models/models.py
@@ -342,12 +342,12 @@ class Submission(PolymorphicModel):
         if not self.finalized:
             self.calculate_grade(commit=False)
 
-        if not self.in_progress and self.is_correct or self.is_partially_correct:
+        if (not self.in_progress and self.is_correct or self.is_partially_correct) or self.question.event.is_exam():
             user_question_junction = self.uqj
             received_tokens = self.grade * get_token_value(self.question.category, self.question.difficulty)
             token_change = received_tokens - user_question_junction.tokens_received
 
-            if token_change > 0:
+            if self.uqj.question.event.is_exam() or token_change > 0:
                 user_question_junction.tokens_received = received_tokens
                 user_question_junction.save()
 

--- a/course/models/models.py
+++ b/course/models/models.py
@@ -252,7 +252,8 @@ class UserQuestionJunction(models.Model):
 
     @property
     def formatted_current_tokens_received(self):
-        return str(self.question.token_value) if self.question.event.is_exam_and_open() \
+        return str(self.question.token_value) \
+            if hasattr(self.question, 'event') and self.question.event.is_exam_and_open() \
             else str(self.tokens_received) + "/" + str(self.question.token_value)
 
     def save(self, **kwargs):
@@ -342,12 +343,13 @@ class Submission(PolymorphicModel):
         if not self.finalized:
             self.calculate_grade(commit=False)
 
-        if (not self.in_progress and self.is_correct or self.is_partially_correct) or self.question.event.is_exam:
+        if not self.in_progress and (self.is_correct or self.is_partially_correct) \
+                or (hasattr(self.question, 'event') and self.question.event.is_exam):
             user_question_junction = self.uqj
             received_tokens = self.grade * get_token_value(self.question.category, self.question.difficulty)
             token_change = received_tokens - user_question_junction.tokens_received
 
-            if self.uqj.question.event.is_exam or token_change > 0:
+            if (hasattr(self.uqj.question, 'event') and self.uqj.question.event.is_exam) or token_change > 0:
                 user_question_junction.tokens_received = received_tokens
                 user_question_junction.save()
 

--- a/course/models/models.py
+++ b/course/models/models.py
@@ -342,12 +342,12 @@ class Submission(PolymorphicModel):
         if not self.finalized:
             self.calculate_grade(commit=False)
 
-        if (not self.in_progress and self.is_correct or self.is_partially_correct) or self.question.event.is_exam():
+        if (not self.in_progress and self.is_correct or self.is_partially_correct) or self.question.event.is_exam:
             user_question_junction = self.uqj
             received_tokens = self.grade * get_token_value(self.question.category, self.question.difficulty)
             token_change = received_tokens - user_question_junction.tokens_received
 
-            if self.uqj.question.event.is_exam() or token_change > 0:
+            if self.uqj.question.event.is_exam or token_change > 0:
                 user_question_junction.tokens_received = received_tokens
                 user_question_junction.save()
 

--- a/course/templates/base_question_view.html
+++ b/course/templates/base_question_view.html
@@ -23,7 +23,9 @@
         <tr>
             <th scope="col">Category</th>
             <th scope="col">Token&nbspValue</th>
-            <th scope="col">Status</th>
+            {% if not question.event.is_exam %}
+                <th scope="col">Status</th>
+            {% endif %}
             <th scope="col">Num&nbsp;Attempts</th>
         </tr>
         </thead>
@@ -31,7 +33,9 @@
         <tr class="{% if question.is_solved %}table-success{% endif %}{% if question.is_wrong %}table-danger{% endif %}{% if question.is_partially_correct %}table-warning{% endif %}">
             <td>{{ question.category }}</td>
             <td>{{ question.token_value | floatformat:0 }}</td>
-            <td>{{ uqj.status }}</td>
+            {% if not question.event.is_exam %}
+                <td>{{ uqj.status }}</td>
+            {% endif %}
             <td>{{ uqj.formatted_num_attempts }}</td>
         </tr>
         </tbody>

--- a/course/templates/base_question_view.html
+++ b/course/templates/base_question_view.html
@@ -66,7 +66,7 @@
     <div class="card my-1">
         <div class="card-header"><h1>My Past Submissions</h1></div>
         <div class="card-body">
-            {% include 'past_submissions_snippet.html' with submissions=uqj.submissions.all %}
+            {% include 'past_submissions_snippet.html' with submissions=uqj.submissions.all event=uqj.question.event %}
         </div>
     </div>
 

--- a/course/templates/past_submissions_snippet.html
+++ b/course/templates/past_submissions_snippet.html
@@ -1,3 +1,5 @@
+{% load arrays %}
+
 <table class="table table-hover">
     <thead>
     <tr>
@@ -5,15 +7,42 @@
         {% if submission_class.show_answer %}
             <th scope="col">Answer</th>
         {% endif %}
-        <th scope="col">Grade</th>
+        {% if not event.is_exam_and_open %}
+            <th scope="col">Grade</th>
+        {% endif %}
         <th scope="col">Time&nbspSubmitted</th>
-        <th scope="col">Status</th>
+        {% if not event.is_exam_and_open %}
+            <th scope="col">Status</th>
+        {% endif %}
         {% if submission_class.show_detail %}
             <th scope="col">Details</th>
         {% endif %}
     </tr>
     </thead>
     <tbody>
+    {% if event.is_exam %}
+        {% return_last_item submissions as graded_submission  %}
+        <tr class="table">
+            <th scope="row">1</th>
+            {% if graded_submission.show_answer %}
+                <td>{{ graded_submission.answer_display }}</td>
+            {% endif %}
+            {% if not event.is_exam_and_open %}
+                <td>{{ graded_submission.grade | floatformat:2 }}</td>
+            {% endif %}
+            <td>{{ graded_submission.submission_time }}</td>
+            {% if not event.is_exam_and_open %}
+                <td>{{ graded_submission.status }}</td>
+            {% endif %}
+            {% if graded_submission.show_detail %}
+                <td>
+                    <button class="btn btn-info"
+                            onclick="window.location.href='{% url 'course:submission_detail' graded_submission.pk %}'">Details
+                    </button>
+                </td>
+            {% endif %}
+        </tr>
+    {% else %}
     {% for submission in submissions reversed %}
         <tr class="table-{{ submission.status_color }}">
             <th scope="row">{{ forloop.revcounter }}</th>
@@ -32,5 +61,6 @@
             {% endif %}
         </tr>
     {% endfor %}
+    {% endif %}
     </tbody>
 </table>

--- a/course/templates/past_submissions_snippet.html
+++ b/course/templates/past_submissions_snippet.html
@@ -23,7 +23,9 @@
     {% if event.is_exam %}
         {% return_last_item submissions as graded_submission  %}
         <tr class="table">
-            <th scope="row">1</th>
+            {% if graded_submission %}
+                <th scope="row">1</th>
+            {% endif %}
             {% if graded_submission.show_answer %}
                 <td>{{ graded_submission.answer_display }}</td>
             {% endif %}

--- a/course/templatetags/arrays.py
+++ b/course/templatetags/arrays.py
@@ -9,3 +9,11 @@ def return_item(arr, i):
         return arr[i]
     except Exception:
         return None
+
+
+@register.simple_tag
+def return_last_item(arr):
+    try:
+        return arr[len(arr) - 1]
+    except Exception:
+        return None

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -67,19 +67,18 @@ def _multiple_choice_question_view(request, question, template_name, key):
 
             if hasattr(question, 'event') and question.event.is_exam:
                 messages.add_message(request, messages.INFO, 'Your submission was received.')
+            elif submission.is_correct:
+                received_tokens = get_user_question_junction(request.user, question).tokens_received
+                messages.add_message(
+                    request, messages.SUCCESS,
+                    'Answer submitted. Your answer was correct. You received {} tokens'.format(
+                        round(received_tokens, 2)),
+                )
             else:
-                if submission.is_correct:
-                    received_tokens = get_user_question_junction(request.user, question).tokens_received
-                    messages.add_message(
-                        request, messages.SUCCESS,
-                        'Answer submitted. Your answer was correct. You received {} tokens'.format(
-                            round(received_tokens, 2)),
-                    )
-                else:
-                    messages.add_message(
-                        request, messages.ERROR,
-                        'Answer submitted. Your answer was wrong',
-                    )
+                messages.add_message(
+                    request, messages.ERROR,
+                    'Answer submitted. Your answer was wrong',
+                )
 
         except SubmissionException as e:
             messages.add_message(request, messages.ERROR, "{}".format(e))

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -65,8 +65,9 @@ def _multiple_choice_question_view(request, question, template_name, key):
         try:
             submission = submit_solution(question, request.user, answer)
 
-            # TODO: after rebasing .is_exam() needs to become .is_exam
-            if not question.event.is_exam:
+            if hasattr(question, 'event') and question.event.is_exam:
+                messages.add_message(request, messages.INFO, 'Your submission was received.')
+            else:
                 if submission.is_correct:
                     received_tokens = get_user_question_junction(request.user, question).tokens_received
                     messages.add_message(

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -65,18 +65,21 @@ def _multiple_choice_question_view(request, question, template_name, key):
         try:
             submission = submit_solution(question, request.user, answer)
 
-            if submission.is_correct:
-                received_tokens = get_user_question_junction(request.user, question).tokens_received
-                messages.add_message(
-                    request, messages.SUCCESS,
-                    'Answer submitted. Your answer was correct. You received {} tokens'.format(
-                        round(received_tokens, 2)),
-                )
-            else:
-                messages.add_message(
-                    request, messages.ERROR,
-                    'Answer submitted. Your answer was wrong',
-                )
+            # TODO: after rebasing .is_exam() needs to become .is_exam
+            if not question.event.is_exam():
+                if submission.is_correct:
+                    received_tokens = get_user_question_junction(request.user, question).tokens_received
+                    messages.add_message(
+                        request, messages.SUCCESS,
+                        'Answer submitted. Your answer was correct. You received {} tokens'.format(
+                            round(received_tokens, 2)),
+                    )
+                else:
+                    messages.add_message(
+                        request, messages.ERROR,
+                        'Answer submitted. Your answer was wrong',
+                    )
+
         except SubmissionException as e:
             messages.add_message(request, messages.ERROR, "{}".format(e))
 

--- a/course/views/multiple_choice.py
+++ b/course/views/multiple_choice.py
@@ -66,7 +66,7 @@ def _multiple_choice_question_view(request, question, template_name, key):
             submission = submit_solution(question, request.user, answer)
 
             # TODO: after rebasing .is_exam() needs to become .is_exam
-            if not question.event.is_exam():
+            if not question.event.is_exam:
                 if submission.is_correct:
                     received_tokens = get_user_question_junction(request.user, question).tokens_received
                     messages.add_message(


### PR DESCRIPTION
## Summary
- for exam events, the grade for a question comes from the latest submission of the student
- removed all fields/styling from the events page, the event questions page, the submissions page and the question summary page that would indicate to the student how they did on a question. These changes include:
    * on the questions summary the value for the exam event in the `Grade` column is set to `Not Available Yet` if the exam is still open
    * on the events questions page for exam, all styling regarding the colour of the rows (based on whether the student's answer was correct or wrong) is disabled
    * on the question summary page, the `Status` column from the table at the top of the page was removed.
        * **QUESTION**: should this status column be `Submitted`/`Unsubmitted` similar to the `Status` column on the events question page?
    * the `Grade` and `Status` (`Correct` or `Wrong`) columns were removed from the `My Past Submissions` table for questions in exam events
    * after a student submits a MC question, the banner showing if the answer was right or wrong is removed
