### PR TITLE
cleanup exam workflow

### DIFF
--- a/canvas/models.py
+++ b/canvas/models.py
@@ -218,6 +218,7 @@ class Event(models.Model):
     def __str__(self):
         return self.name
 
+    @property
     def is_open(self):
         return self.start_date <= timezone.now() <= self.end_date
 
@@ -242,13 +243,13 @@ class Event(models.Model):
     def has_view_permission(self, user):
         if self.course.is_instructor(user) or user.is_teacher:
             return True
-        return self.is_open() and self.course.is_registered(user)
+        return self.is_open and self.course.is_registered(user)
 
     def has_edit_permission(self, user):
         return self.course.is_instructor(user) or user.is_teacher
 
     def is_allowed_to_open(self, user):
-        return self.course.is_registered(user) and self.is_open()
+        return self.course.is_registered(user) and self.is_open
 
     def can_view_results(self, user):
         return self.is_closed() and self.course.is_registered(user)
@@ -257,7 +258,7 @@ class Event(models.Model):
         return self.is_not_available_yet() and self.course.is_registered(user)
 
     def is_exam_and_open(self):
-        return self.is_exam and self.is_open()
+        return self.is_exam and self.is_open
 
 
 class TokenUseOption(models.Model):

--- a/course/templates/base_question_view.html
+++ b/course/templates/base_question_view.html
@@ -22,7 +22,11 @@
         <thead>
         <tr>
             <th scope="col">Category</th>
-            <th scope="col">Token&nbspValue</th>
+            {% if question.event.is_exam %}
+                <th scope="col">Tokens Worth</th>
+            {% else %}
+                <th scope="col">Token&nbspValue</th>
+            {% endif %}
             {% if not question.event.is_exam %}
                 <th scope="col">Status</th>
             {% endif %}
@@ -70,6 +74,9 @@
     <div class="card my-1">
         <div class="card-header"><h1>My Past Submissions</h1></div>
         <div class="card-body">
+            {% if not question.event.is_exam %}
+                <b>Only the submission with the highest token received value will be awarded</b></p>
+            {% endif %}
             {% include 'past_submissions_snippet.html' with submissions=uqj.submissions.all event=uqj.question.event %}
         </div>
     </div>

--- a/course/templates/code_submission_detail.html
+++ b/course/templates/code_submission_detail.html
@@ -25,12 +25,15 @@
                 <th>
                     Time Submitted
                 </th>
-                <th>
-                    Grade
-                </th>
-                <th>
-                    Status
-                </th>
+                {% if not submission.uqj.question.event.is_exam_and_open %}
+                     <th>
+                        Grade
+                    </th>
+                    <th>
+                        Status
+                    </th>
+                {% endif %}
+
             </tr>
             </thead>
             <tbody>
@@ -41,12 +44,14 @@
                 <td>
                     {{ submission.submission_time }}
                 </td>
-                <td>
-                    {{ submission.grade }}
-                </td>
-                <td>
-                    {{ submission.status }}
-                </td>
+                {% if not submission.uqj.question.event.is_exam_and_open %}
+                    <td>
+                        {{ submission.grade }}
+                    </td>
+                    <td>
+                        {{ submission.status }}
+                    </td>
+                {% endif %}
             </tr>
             </tbody>
         </table>
@@ -99,6 +104,9 @@
                         <h5>Score: {{ submission.get_formatted_test_results }}</h5>
                     </div>
                     <div>
+                        <h5>Tokens Received: {{ submission.formatted_tokens_received }}</h5>
+                    </div>
+                    <div>
                         {% if submission.get_passed_test_results %}
                             <h5>What went well:</h5>
                             <ul>
@@ -123,11 +131,14 @@
                     <p>This is usually due to compilation error or your answer is still being evaluated, see compile
                         output or refresh the page</p>
                 {% endif %}
-                <button class="btn btn-info"
-                        onclick="window.location.href='{% url 'course:question_view' submission.uqj.question.pk %}'">
-                    Re-Attempt
-                </button>
             </div>
         </div>
     {% endif %}
+    {% if submission.uqj.is_allowed_to_submit %}
+        <button class="btn btn-info"
+            onclick="window.location.href='{% url 'course:question_view' submission.uqj.question.pk %}'">
+        Re-Attempt
+    </button>
+    {% endif %}
+
 {% endblock %}

--- a/course/templates/past_submissions_snippet.html
+++ b/course/templates/past_submissions_snippet.html
@@ -1,4 +1,5 @@
 {% load arrays %}
+{% load course %}
 
 <table class="table table-hover">
     <thead>
@@ -10,6 +11,9 @@
         {% if not event.is_exam_and_open %}
             <th scope="col">Grade</th>
         {% endif %}
+        {% if not event.is_exam_and_open %}
+            <th scope="col">Tokens Received</th>
+        {% endif %}
         <th scope="col">Time&nbspSubmitted</th>
         {% if not event.is_exam_and_open %}
             <th scope="col">Status</th>
@@ -20,40 +24,23 @@
     </tr>
     </thead>
     <tbody>
-    {% if event.is_exam %}
-        {% return_last_item submissions as graded_submission  %}
-        <tr class="table">
-            {% if graded_submission %}
-                <th scope="row">1</th>
-            {% endif %}
-            {% if graded_submission.show_answer %}
-                <td>{{ graded_submission.answer_display }}</td>
-            {% endif %}
-            {% if not event.is_exam_and_open %}
-                <td>{{ graded_submission.grade | floatformat:2 }}</td>
-            {% endif %}
-            <td>{{ graded_submission.submission_time }}</td>
-            {% if not event.is_exam_and_open %}
-                <td>{{ graded_submission.status }}</td>
-            {% endif %}
-            {% if graded_submission.show_detail %}
-                <td>
-                    <button class="btn btn-info"
-                            onclick="window.location.href='{% url 'course:submission_detail' graded_submission.pk %}'">Details
-                    </button>
-                </td>
-            {% endif %}
-        </tr>
-    {% else %}
     {% for submission in submissions reversed %}
-        <tr class="table-{{ submission.status_color }}">
+        {% row_class submission event as row_class_name %}
+        <tr class={{ row_class_name }}>
             <th scope="row">{{ forloop.revcounter }}</th>
             {% if submission_class.show_answer %}
                 <td>{{ submission.answer_display }}</td>
             {% endif %}
-            <td>{{ submission.grade | floatformat:2 }}</td>
+            {% if not event.is_exam_and_open %}
+                <td>{{ submission.grade | floatformat:2 }}</td>
+            {% endif %}
+            {% if not event.is_exam_and_open %}
+                <td>{{ submission.formatted_tokens_received }}</td>
+            {% endif %}
             <td>{{ submission.submission_time }}</td>
-            <td>{{ submission.status }}</td>
+            {% if not event.is_exam_and_open %}
+                <td>{{ submission.status }}</td>
+            {% endif %}
             {% if submission_class.show_detail %}
                 <td>
                     <button class="btn btn-info"
@@ -63,6 +50,5 @@
             {% endif %}
         </tr>
     {% endfor %}
-    {% endif %}
     </tbody>
 </table>

--- a/course/templatetags/course.py
+++ b/course/templatetags/course.py
@@ -1,0 +1,10 @@
+from canvas.models import Event
+from canvas.templatetags.canvas import register
+
+
+@register.simple_tag
+def row_class(submission, event):
+    if isinstance(event, Event) and event.is_exam:
+        return ""
+    else:
+        return "table-" + submission.status_color


### PR DESCRIPTION
- For open exams, remove the status and grade columns from the Submission Details page
- In exam buttons, add "Re-attempt" button below the compiled successful message for open exams
- On the Question Summary page, change "Token Value" to "Tokens Worth" for open exam events
- For exams, show all past submissions