### PR TITLE
Fix UQJ Permissions

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -17,11 +17,3 @@ class UserConsentPermission(permissions.IsAuthenticated):
 
     def has_object_permission(self, request, view, obj):
         return request.user == obj.user
-
-
-class UQJViewPermission(permissions.IsAuthenticated):
-    def has_permission(self, request, view):
-        return super().has_permission(request, view)
-
-    def has_object_permission(self, request, view, obj):
-        return obj.has_view_permission(request.user)

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -17,3 +17,11 @@ class UserConsentPermission(permissions.IsAuthenticated):
 
     def has_object_permission(self, request, view, obj):
         return request.user == obj.user
+
+
+class UQJViewPermission(permissions.IsAuthenticated):
+    def has_permission(self, request, view):
+        return super().has_permission(request, view)
+
+    def has_object_permission(self, request, view, obj):
+        return obj.has_view_permission(request.user)

--- a/api/views/uqj.py
+++ b/api/views/uqj.py
@@ -20,4 +20,13 @@ class UQJViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return user.question_junctions.all()
+        uqj = user.question_junctions.filter(user=user)
+        accessible_uqj = []
+        for temp in uqj:
+            if temp.question.has_view_permission(user):
+                accessible_uqj.append(temp)
+            # TODO remove uqj from queryset if user does not have view permission.
+            # else:
+            # uqj = uqj.exclude(temp)
+        print(accessible_uqj)
+        return uqj

--- a/api/views/uqj.py
+++ b/api/views/uqj.py
@@ -3,6 +3,7 @@ from rest_framework import viewsets, filters
 from rest_framework.permissions import IsAuthenticated
 
 from api.pagination import BasePagination
+from api.permissions import UQJViewPermission
 from api.serializers import UQJSerializer
 
 
@@ -12,7 +13,7 @@ class UQJViewSet(viewsets.ReadOnlyModelViewSet):
     + Standard ordering is applied on the field 'last_viewed'
     """
     serializer_class = UQJSerializer
-    permission_classes = [IsAuthenticated, ]
+    permission_classes = [IsAuthenticated, UQJViewPermission, ]
     pagination_class = BasePagination
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter, ]
     ordering_fields = ['last_viewed', ]
@@ -20,13 +21,13 @@ class UQJViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        uqj = user.question_junctions.filter(user=user)
-        accessible_uqj = []
-        for temp in uqj:
-            if temp.question.has_view_permission(user):
-                accessible_uqj.append(temp)
-            # TODO remove uqj from queryset if user does not have view permission.
-            # else:
-            # uqj = uqj.exclude(temp)
-        print(accessible_uqj)
+        uqj = user.question_junctions.all()
+        # accessible_uqj = []
+        # for temp in uqj:
+        #     if temp.question.has_view_permission(user):
+        #         accessible_uqj.append(temp)
+        #     # TODO remove uqj from queryset if user does not have view permission.
+        #     # else:
+        #     # uqj = uqj.exclude(temp)
+        # print(accessible_uqj)
         return uqj

--- a/api/views/uqj.py
+++ b/api/views/uqj.py
@@ -3,7 +3,6 @@ from rest_framework import viewsets, filters
 from rest_framework.permissions import IsAuthenticated
 
 from api.pagination import BasePagination
-from api.permissions import UQJViewPermission
 from api.serializers import UQJSerializer
 
 
@@ -13,7 +12,7 @@ class UQJViewSet(viewsets.ReadOnlyModelViewSet):
     + Standard ordering is applied on the field 'last_viewed'
     """
     serializer_class = UQJSerializer
-    permission_classes = [IsAuthenticated, UQJViewPermission, ]
+    permission_classes = [IsAuthenticated, ]
     pagination_class = BasePagination
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter, ]
     ordering_fields = ['last_viewed', ]
@@ -22,12 +21,9 @@ class UQJViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         user = self.request.user
         uqj = user.question_junctions.all()
-        # accessible_uqj = []
-        # for temp in uqj:
-        #     if temp.question.has_view_permission(user):
-        #         accessible_uqj.append(temp)
-        #     # TODO remove uqj from queryset if user does not have view permission.
-        #     # else:
-        #     # uqj = uqj.exclude(temp)
-        # print(accessible_uqj)
+        accessible_uqj = []
+        for temp in uqj:
+            if temp.question.has_view_permission(user):
+                accessible_uqj.append(temp.question)
+        uqj = user.question_junctions.filter(question__in=accessible_uqj)
         return uqj


### PR DESCRIPTION
Fix for the bug where users could see UQJs that they did not have permission to view. Solution is a little weird but I could not find a better solution that did what we needed.
Closes #168 