### PR TITLE
Removing use of "registered" for permissions in the Course API

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -17,3 +17,12 @@ class UserConsentPermission(permissions.IsAuthenticated):
 
     def has_object_permission(self, request, view, obj):
         return request.user == obj.user
+
+
+class StudentsMustBeRegisteredPermission(permissions.IsAuthenticated):
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        course = obj
+        if user.is_student and not course.is_registered(user):
+            return False
+        return True

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -27,4 +27,4 @@ from .multiple_choice_question import MultipleChoiceQuestionSerializer, Multiple
 from .parsons_question import ParsonsQuestionSerializer, ParsonsSubmissionSerializer
 from .uqj import UQJSerializer
 from .canvas_course_registration import CanvasCourseRegistrationSerializer
-from .course import CourseSerializer
+from .course import CourseSerializer, CourseSerializerList

--- a/api/serializers/course.py
+++ b/api/serializers/course.py
@@ -60,4 +60,29 @@ class CourseSerializer(serializers.ModelSerializer):
         model = CanvasCourse
         fields = ['id', 'mock', 'name', 'url', 'course_id', 'token', 'allow_registration', 'visible_to_students',
                   'start_date', 'end_date', 'instructor', 'status', 'is_registered', 'token_use_options', 'events',
-                  'uqjs', 'question_set', 'course_reg', 'leader_board']
+                  'uqjs', 'question_set', 'course_reg', 'leader_board', ]
+
+
+class CourseSerializerList(serializers.ModelSerializer):
+    is_registered = serializers.SerializerMethodField('get_is_registered')
+    events = EventSerializer(many=True, read_only=True)
+
+    def get_user(self):
+        user = MyAnonymousUser()
+        request = self.context.get("request")
+        if request and hasattr(request, "user"):
+            user = request.user
+        return user
+
+    def get_is_registered(self, course):
+        user = self.get_user()
+        # if user is not logged in or the request has no user attached
+        if not user.is_authenticated:
+            return False
+
+        return course.is_registered(user)
+
+    class Meta:
+        model = CanvasCourse
+        fields = ['id', 'mock', 'name', 'url', 'course_id', 'allow_registration', 'visible_to_students', 'start_date',
+                  'end_date', 'instructor', 'status', 'is_registered', 'events', ]

--- a/api/views/course.py
+++ b/api/views/course.py
@@ -3,7 +3,6 @@ from rest_framework import filters, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
-from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from api.serializers import CourseSerializer, CourseSerializerList
@@ -197,8 +196,6 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         """
         User stats.
         """
-        course = get_object_or_404(CanvasCourse, pk=pk)
-
         success_rate = 0
         for pair in request.user.success_rate_by_category:
             if pair['category'] == int(category_pk):

--- a/api/views/course.py
+++ b/api/views/course.py
@@ -6,7 +6,8 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from api.serializers import CourseSerializer
+from api.serializers import CourseSerializer, CourseSerializerList
+from api.permissions import StudentsMustBeRegisteredPermission
 from canvas.models import CanvasCourse, CanvasCourseRegistration
 from canvas.utils.utils import get_course_registration
 
@@ -17,12 +18,22 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     ?registered: boolean => if true, filter retrieved courses by if user is currently registered in them
     """
     serializer_class = CourseSerializer
-    permission_classes = [IsAuthenticated, ]
-    filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
-    filterset_fields = ['mock', 'name', 'allow_registration', 'visible_to_students', 'instructor']
+    action_serializers = {
+        'retrieve': CourseSerializer,
+        'list': CourseSerializerList,
+    }
+    permission_classes = [StudentsMustBeRegisteredPermission, ]
+    filter_backends = [DjangoFilterBackend, filters.OrderingFilter, ]
+    filterset_fields = ['mock', 'name', 'allow_registration', 'visible_to_students', 'instructor', ]
     ordering_fields = ['name', 'start_date', 'end_date', ]
 
-    def get_queryset(self):
+    def get_serializer_class(self):
+        if hasattr(self, 'action_serializers'):
+            return self.action_serializers.get(self.action, self.serializer_class)
+
+        return super(CourseViewSet, self).get_serializer_class()
+
+    def get_queryset(self, *args, **kwargs):
         user = self.request.user
         registered = self.request.query_params.get('registered', None)
         if registered:
@@ -170,14 +181,8 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
         Validates that an event belongs to a particular course.
         """
         course = get_object_or_404(CanvasCourse, pk=pk)
-        registered = self.request.query_params.get('registered', None)
-        if registered:
-            registered = registered.lower() == 'true'
 
         if course is None:
-            raise ValidationError()
-
-        if registered and not course.is_registered(request.user):
             raise ValidationError()
 
         if course.events.filter(pk=event_pk).exists():
@@ -189,16 +194,10 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
 
     @action(detail=True, methods=['get'], url_path='user-stats/(?P<category_pk>[^/.]+)')
     def user_stats(self, request, pk=None, category_pk=None):
+        """
+        User stats.
+        """
         course = get_object_or_404(CanvasCourse, pk=pk)
-        registered = self.request.query_params.get('registered', None)
-        if registered:
-            registered = registered.lower() == 'true'
-
-        if course is None:
-            raise ValidationError()
-
-        if registered and not course.is_registered(request.user):
-            raise ValidationError()
 
         success_rate = 0
         for pair in request.user.success_rate_by_category:


### PR DESCRIPTION
Attach proper permissions and context-based serialization to the Course API. i.e. list view returns shallow information and detailed view (with more required permissions) returns deep information.

Closes #173 