### PR TITLE
Quick Fix for User Consents

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -33,6 +33,11 @@ class QuestionPermission(permissions.IsAuthenticated):
 
 
 class UserConsentPermission(permissions.IsAuthenticated):
+    def has_permission(self, request, view):
+        if view.detail:
+            return True
+        return False
+
     def has_object_permission(self, request, view, obj):
         if request.method in ["GET", "POST"]:
             return request.user == obj.user


### PR DESCRIPTION
### Description
- prevents any authenticated user from accessing the entire list of user consents
- this will temporarily break consents on the F/e (as the consent service needs to be fixed)