### PR TITLE
add hidden file processing

### DIFF
--- a/course/models/java.py
+++ b/course/models/java.py
@@ -12,6 +12,8 @@ class JavaQuestion(VariableQuestion):
             "name": string
             "compile": boolean // whether to compile this input as a separate file or not
             "template": string
+            "hidden": boolean // whether this file should not be displayed to the user and added to the submission later
+
         }...]
     """
     junit_template = models.TextField()

--- a/course/services/submission.py
+++ b/course/services/submission.py
@@ -20,6 +20,11 @@ def submit_java_solution(question, user, answer_dict):
     submission.answer_files = answer_dict
     submission.uqj = uqj
 
+    for input_file in uqj.get_input_files():
+        if 'hidden' in input_file.keys() and input_file['hidden']:
+            hidden_file = {input_file['name']: input_file['template']}
+            submission.answer_files.update(hidden_file)
+
     submission.submit()
     submission.save()
     uqj.save()

--- a/course/services/submission.py
+++ b/course/services/submission.py
@@ -21,8 +21,8 @@ def submit_java_solution(question, user, answer_dict):
     submission.uqj = uqj
 
     for input_file in uqj.get_input_files():
-        if 'hidden' in input_file.keys() and input_file['hidden']:
-            hidden_file = {input_file['name']: input_file['template']}
+        if "hidden" in input_file.keys() and input_file["hidden"]:
+            hidden_file = {input_file["name"]: input_file["template"]}
             submission.answer_files.update(hidden_file)
 
     submission.submit()


### PR DESCRIPTION
This is part 1 of this pr set, it has a matching front end one i'll push once this is merged. 

Added functionality such that on every Java question submission it checks if any of the input_files in the dictionary have the hidden key and if so adds the appropriate components of that file onto the dictionary containing the submitted code files since the idea is that the file itself is not shown to or modified by the users so it is not bundled in with the initial submission package. 