### PR TITLE
add account activation to reset password

### DIFF
--- a/api/serializers/reset_password.py
+++ b/api/serializers/reset_password.py
@@ -43,5 +43,6 @@ class ResetPasswordSerializer(serializers.ModelSerializer):
         uid = force_text(urlsafe_base64_decode(validated_data["uid"]))
         user = MyUser.objects.get(pk=uid)
         user.set_password(validated_data["password"])
+        user.is_active = True
         user.save()
         return user


### PR DESCRIPTION
added account activation for resetting password because this too validates an existing email. Should prevent students form missing the activation link and requesting staff support when password reset doesn't work.