### PR TITLE
Fix: Angular app returns 500 for every request under DEBUG=false

### DIFF
--- a/canvas_gamification/views.py
+++ b/canvas_gamification/views.py
@@ -17,10 +17,10 @@ def angular(request, path="index.html", document_root=None):
     if not fullpath.exists():
         fullpath = Path(safe_join(document_root, "index.html"))
     statobj = fullpath.stat()
+    # Django 4.1 dropped was_modified_since()'s third "size" argument.
     if not was_modified_since(
         request.META.get("HTTP_IF_MODIFIED_SINCE"),
         statobj.st_mtime,
-        statobj.st_size,
     ):
         return HttpResponseNotModified()
     content_type, encoding = mimetypes.guess_type(str(fullpath))

--- a/test/baseline/test_angular_serving.py
+++ b/test/baseline/test_angular_serving.py
@@ -1,0 +1,86 @@
+"""Serving of the built Angular bundle by canvas_gamification.views.angular.
+
+These run against the production URLconf: urls.py branches on settings.DEBUG at
+import time, and Django's test runner forces DEBUG off, so the catch-all that
+serves static/angular is the one under test here (the DEBUG URLconf does not
+mount it at all).
+
+Nothing else in the suite requests a non-API path, which is how the Django 4.1
+signature change to was_modified_since() -- it lost its third "size" argument --
+reached master and turned every page and asset in a DEBUG=false deployment into
+a 500.
+"""
+
+import os
+
+from django.conf import settings
+from django.test import TestCase
+from django.utils.http import http_date
+
+ANGULAR_ROOT = os.path.join(settings.BASE_DIR, "static", "angular")
+
+
+def read_response(response):
+    if response.streaming:
+        return b"".join(response.streaming_content)
+    return response.content
+
+
+def find_bundle():
+    """Any hashed .js bundle at the root of the build output.
+
+    Discovered rather than hard-coded: the file names carry content hashes and
+    change on every frontend build.
+    """
+    for name in sorted(os.listdir(ANGULAR_ROOT)):
+        if name.endswith(".js"):
+            return name
+    return None
+
+
+class AngularServingTest(TestCase):
+    def test_root_serves_index_html(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/html")
+        self.assertIn(b"<app-root", read_response(response))
+
+    def test_root_sets_last_modified(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.has_header("Last-Modified"))
+
+    def test_hashed_bundle_is_served_with_its_own_content_type(self):
+        bundle = find_bundle()
+        self.assertIsNotNone(bundle, "no .js bundle in static/angular -- has the frontend been built?")
+
+        response = self.client.get("/" + bundle)
+        self.assertEqual(response.status_code, 200)
+        # Serves the real file, not the index.html fallback.
+        self.assertIn("javascript", response["Content-Type"])
+        with open(os.path.join(ANGULAR_ROOT, bundle), "rb") as f:
+            self.assertEqual(read_response(response), f.read())
+
+    def test_unknown_path_falls_back_to_index_html(self):
+        # Client-side routes must reach the Angular app rather than 404.
+        response = self.client.get("/some/client/side/route")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/html")
+        with open(os.path.join(ANGULAR_ROOT, "index.html"), "rb") as f:
+            self.assertEqual(read_response(response), f.read())
+
+    def test_if_modified_since_in_the_future_returns_304(self):
+        # The direct regression test for the was_modified_since() signature:
+        # this is the only branch that calls it with a header present.
+        response = self.client.get("/", HTTP_IF_MODIFIED_SINCE=http_date(2**31 - 1))
+        self.assertEqual(response.status_code, 304)
+
+    def test_if_modified_since_in_the_past_returns_the_file(self):
+        response = self.client.get("/", HTTP_IF_MODIFIED_SINCE=http_date(0))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"<app-root", read_response(response))
+
+    def test_api_routes_are_not_swallowed_by_the_catch_all(self):
+        # The catch-all is registered last; /api/ must still reach the API.
+        response = self.client.get("/api/course/")
+        self.assertIn(response.status_code, [401, 403])


### PR DESCRIPTION
**The Angular app currently returns 500 for every request in any `DEBUG=false` deployment.** Two files, split out of #405 so it can be reviewed on its own.

## The bug

Django 4.1 removed the third `size` argument from `django.views.static.was_modified_since`, but `canvas_gamification/views.py` still passed `statobj.st_size`:

```python
if not was_modified_since(
    request.META.get("HTTP_IF_MODIFIED_SINCE"),
    statobj.st_mtime,
    statobj.st_size,        # <- TypeError on Django >= 4.1
):
```

`views.angular` is what serves `static/angular`, and the catch-all that routes to it is mounted **only in the non-DEBUG URLconf** (`canvas_gamification/urls.py`). So development is completely unaffected, while a real deployment serves a 500 for every page and every asset.

Introduced by the Django 6 upgrade in #404.

## Why the test suite missed it

The 760-test suite sweeps every `/api/` route and every admin page, but never requests a path through the catch-all — so the one view that only exists in production was the one view nothing exercised. It surfaced only when the built bundle was served in production shape (`DEBUG=false`, PostgreSQL, real browser).

## The regression test

`test/baseline/test_angular_serving.py` covers what was missing:

- `/` serves `index.html`
- a hashed bundle is served with its own content type — i.e. the real file, not the fallback
- an unknown path falls back to `index.html`, so client-side routes work
- **both `If-Modified-Since` branches** — the crash is only reachable when that header is present, so without this case the bug would still slip through
- `/api/` is not swallowed by the catch-all

**Six of the seven fail without the one-line fix** (verified by reverting it, not assumed). The bundle filename is discovered at runtime rather than hard-coded, since it carries a content hash that changes on every frontend build.

These run against the production URLconf: `urls.py` branches on `settings.DEBUG` at import time and Django's test runner forces `DEBUG` off, so the catch-all is live under test.

## Verification

- 767/767 tests pass (760 existing + these 7).
- Passes against both the currently-committed bundle and the refreshed one in #405.
- Manually confirmed against a real server: `DEBUG=false` + PostgreSQL 17, driven in headless chromium — app boots, deep links and hard reloads work, login completes end to end.

Merge this before #405; that PR's refreshed bundle is unservable without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
