### PR TITLE
Fix: admin login fails CSRF Origin check behind the TLS-terminating proxy

### DIFF
--- a/canvas_gamification/csrf.py
+++ b/canvas_gamification/csrf.py
@@ -1,0 +1,23 @@
+def trusted_origins(allowed_hosts):
+    """Build CSRF_TRUSTED_ORIGINS entries from ALLOWED_HOSTS.
+
+    Django 4.0 started rejecting unsafe-method requests whose Origin header does
+    not match the expected origin. The expected origin is built from
+    request.is_secure(), so behind a TLS-terminating reverse proxy Django
+    computes "http://host" while the browser sends "https://host", and every
+    admin login POST fails with "Origin checking failed".
+
+    Only https origins are listed. A plain-http deployment does not need an
+    entry: there is_secure() is genuinely False, so Django's own expected
+    origin already matches what the browser sends.
+
+    "*" is skipped -- it is not a valid origin. A leading-dot wildcard host
+    such as ".example.com" becomes "https://*.example.com", which is the form
+    CSRF_TRUSTED_ORIGINS expects.
+    """
+    origins = []
+    for host in allowed_hosts:
+        if host == "*":
+            continue
+        origins.append("https://" + ("*" + host if host.startswith(".") else host))
+    return origins

--- a/canvas_gamification/settings.py
+++ b/canvas_gamification/settings.py
@@ -18,6 +18,7 @@ from django.contrib.messages import constants as message_constants
 from django.urls import reverse_lazy
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from canvas_gamification.csrf import trusted_origins
 from canvas_gamification.env import read_env
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -42,6 +43,15 @@ elif DEBUG:
     ALLOWED_HOSTS = ["*"]
 else:
     ALLOWED_HOSTS = os.environ["SERVER_NAME"].split()
+
+# The app runs behind a reverse proxy that terminates TLS (see env/nginx.conf),
+# so the request reaching gunicorn is plain HTTP. Trust the forwarded scheme,
+# otherwise request.is_secure() is False for genuinely secure requests.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Django 4.0+ rejects unsafe-method requests whose Origin does not match the
+# expected origin, which breaks admin login behind TLS termination.
+CSRF_TRUSTED_ORIGINS = trusted_origins(ALLOWED_HOSTS)
 
 # Application definition
 

--- a/env/nginx.conf
+++ b/env/nginx.conf
@@ -5,13 +5,22 @@ events {
 http {
   client_max_body_size 20m;
 
+  # Preserve the scheme the browser actually used. This nginx sits behind the
+  # host's own TLS-terminating nginx, so $scheme here is always "http" and
+  # would otherwise overwrite the upstream X-Forwarded-Proto, leaving Django
+  # unable to tell that the original request was HTTPS.
+  map $http_x_forwarded_proto $forwarded_proto {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+  }
+
   server {
     listen 8000 default_server;
 
     location / {
       proxy_pass http://web:8000;
       proxy_set_header HOST $host;
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $forwarded_proto;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/test/baseline/test_csrf_behind_proxy.py
+++ b/test/baseline/test_csrf_behind_proxy.py
@@ -1,0 +1,132 @@
+"""CSRF and forwarded-scheme handling behind the reverse proxy.
+
+Django 4.0 added strict Origin checking to CsrfViewMiddleware. The expected
+origin is derived from request.is_secure(), so with TLS terminated upstream and
+the forwarded scheme ignored, Django compares "http://host" against the
+browser's "https://host" and rejects every unsafe-method request from a
+session-authenticated page -- in practice, admin login.
+
+The API is unaffected (token and basic auth, which are CSRF-exempt), which is
+why nothing else in the suite covers this.
+"""
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import Client, RequestFactory, TestCase, override_settings
+
+from canvas_gamification.csrf import trusted_origins
+
+
+class TrustedOriginsTest(TestCase):
+    def test_builds_https_origins(self):
+        self.assertEqual(trusted_origins(["example.com"]), ["https://example.com"])
+
+    def test_skips_the_wildcard_host(self):
+        # "*" is a valid ALLOWED_HOSTS entry but not a valid origin.
+        self.assertEqual(trusted_origins(["*"]), [])
+
+    def test_leading_dot_becomes_a_wildcard_origin(self):
+        self.assertEqual(trusted_origins([".example.com"]), ["https://*.example.com"])
+
+    def test_multiple_hosts_keep_their_order(self):
+        self.assertEqual(
+            trusted_origins(["a.example.com", "*", "b.example.com"]),
+            ["https://a.example.com", "https://b.example.com"],
+        )
+
+    def test_empty_allowed_hosts(self):
+        self.assertEqual(trusted_origins([]), [])
+
+    def test_every_configured_origin_is_https_and_well_formed(self):
+        # Not compared against ALLOWED_HOSTS directly: the test runner appends
+        # "testserver" to it at runtime, after settings were imported.
+        for origin in settings.CSRF_TRUSTED_ORIGINS:
+            self.assertTrue(origin.startswith("https://"), origin)
+            self.assertNotEqual(origin, "https://*")
+
+
+class ForwardedSchemeTest(TestCase):
+    def test_secure_proxy_ssl_header_is_configured(self):
+        self.assertEqual(settings.SECURE_PROXY_SSL_HEADER, ("HTTP_X_FORWARDED_PROTO", "https"))
+
+    def test_request_is_secure_when_the_proxy_forwards_https(self):
+        request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="https")
+        self.assertTrue(request.is_secure())
+
+    def test_request_is_not_secure_without_the_header(self):
+        self.assertFalse(RequestFactory().get("/").is_secure())
+
+    def test_request_is_not_secure_when_the_proxy_forwards_http(self):
+        request = RequestFactory().get("/", HTTP_X_FORWARDED_PROTO="http")
+        self.assertFalse(request.is_secure())
+
+
+class AdminLoginOriginTest(TestCase):
+    """The actual regression: a CSRF-enforcing POST to the admin login form."""
+
+    def setUp(self):
+        self.password = "sup3r-s3cret-pw"
+        get_user_model().objects.create_superuser(
+            username="csrf-admin",
+            email="csrf-admin@example.com",
+            password=self.password,
+        )
+        self.client = Client(enforce_csrf_checks=True)
+
+    def post_login(self, **extra):
+        # A real browser round trip: fetch the form for its CSRF cookie, then
+        # post the matching token back.
+        #
+        # HTTP_HOST is set explicitly because the test client's environ carries
+        # SERVER_PORT=80; once a request counts as HTTPS, get_host() would
+        # append that port and produce "testserver:80". Nginx forwards the
+        # real Host header (proxy_set_header HOST $host), so this matches
+        # production rather than working around it.
+        extra.setdefault("HTTP_HOST", "testserver")
+        self.client.get("/admin/login/")
+        token = self.client.cookies["csrftoken"].value
+        return self.client.post(
+            "/admin/login/",
+            {
+                "username": "csrf-admin",
+                "password": self.password,
+                "csrfmiddlewaretoken": token,
+                "next": "/admin/",
+            },
+            **extra,
+        )
+
+    def test_https_origin_is_accepted_when_the_proxy_forwards_https(self):
+        # The regression case: this is what a browser sends to the admin login
+        # form through the TLS-terminating proxy.
+        response = self.post_login(
+            HTTP_ORIGIN="https://testserver",
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_https_origin_is_rejected_without_the_forwarded_scheme(self):
+        # Pins the pre-fix behaviour: this is exactly what a TLS-terminating
+        # proxy produced before SECURE_PROXY_SSL_HEADER was set.
+        response = self.post_login(HTTP_ORIGIN="https://testserver")
+        self.assertEqual(response.status_code, 403)
+
+    def test_foreign_origin_is_still_rejected(self):
+        response = self.post_login(
+            HTTP_ORIGIN="https://evil.example.com",
+            HTTP_X_FORWARDED_PROTO="https",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(ALLOWED_HOSTS=["testserver"], CSRF_TRUSTED_ORIGINS=["https://testserver"])
+    def test_trusted_origin_is_accepted_even_without_the_forwarded_scheme(self):
+        # The second, independent mechanism: CSRF_TRUSTED_ORIGINS is consulted
+        # regardless of is_secure(), so a deployment whose proxy does not send
+        # X-Forwarded-Proto is still covered.
+        response = self.post_login(HTTP_ORIGIN="https://testserver")
+        self.assertEqual(response.status_code, 302)
+
+    def test_same_origin_http_still_works(self):
+        # A plain-http deployment needs no trusted origin at all.
+        response = self.post_login(HTTP_ORIGIN="http://testserver")
+        self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
**Logging into `/admin/` over HTTPS currently fails with "CSRF verification failed. Origin checking failed."** Found while writing the deploy runbook for #404; worth landing before the next deploy rather than discovering it in production.

## The bug

Django 4.0 added strict `Origin` checking to `CsrfViewMiddleware`. The expected origin is built from `request.is_secure()` (`django/middleware/csrf.py:278`):

```python
good_origin = "%s://%s" % ("https" if request.is_secure() else "http", good_host)
```

The host's nginx terminates TLS and proxies plain HTTP to the compose stack, so `is_secure()` is `False`. Django expects `http://host`, the browser sends `https://host`, and the request is rejected.

Django 3.0 had no such check, so this arrived with the Django 6 upgrade in #404. The suite didn't catch it because the API uses token and basic auth, which are CSRF-exempt — only session-authenticated POSTs are affected, which in practice means the Django admin.

## The fix — two independent mechanisms

Either one alone fixes it; both are included so the deployment is covered whatever the proxy sends.

**1. `SECURE_PROXY_SSL_HEADER`** makes `is_secure()` reflect the browser's scheme, so Django's own expected origin becomes `https`.

This required an `env/nginx.conf` change to be worth anything. The compose nginx was overwriting the header with its own `$scheme` — which is *always* `http`, since it sits behind the host nginx — discarding the real scheme:

```diff
-      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Proto $forwarded_proto;
```

with a `map` that prefers the upstream value and falls back to `$scheme` when it is absent. So it behaves correctly whether or not the host nginx sets the header.

**2. `CSRF_TRUSTED_ORIGINS`**, derived from `ALLOWED_HOSTS` via the new `canvas_gamification/csrf.py`. This is consulted regardless of `is_secure()`, so it covers a proxy that never sends `X-Forwarded-Proto`.

Only `https` origins are listed. A plain-HTTP deployment needs no entry: there `is_secure()` is genuinely `False`, so Django's expected origin already matches what the browser sends. `"*"` is skipped (not a valid origin) and a leading-dot host such as `.example.com` becomes `https://*.example.com`.

## Tests

`test/baseline/test_csrf_behind_proxy.py` — 15 tests covering the derivation helper, forwarded-scheme handling, and a CSRF-enforcing admin login POST: accepted with a matching `https` Origin, still rejected for a foreign one, and accepted via the trusted-origins path when the forwarded scheme is missing.

**Three fail with the settings reverted** (verified by reverting them, not assumed). Full suite: **782/782**.

One detail worth knowing if you read the test: it sets `HTTP_HOST` explicitly. The test client's environ carries `SERVER_PORT=80`, so once a request counts as HTTPS, `get_host()` would append that port and yield `testserver:80`. Nginx forwards the real `Host` header (`proxy_set_header HOST $host`), so setting it matches production rather than papering over a discrepancy.

## Unrelated hardening worth considering

`docker-compose.yml` publishes `8000:8000`, which binds all interfaces — so the compose nginx is reachable directly, bypassing the host nginx, and a client could set `X-Forwarded-Proto` itself. Nothing security-relevant depends on the scheme here (there is no `SECURE_SSL_REDIRECT` or secure-cookie enforcement), but binding to `127.0.0.1:8000` would be tighter if the host nginx proxies to localhost. Left alone since I can't see the host nginx config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
