### PR TITLE
security: take SECRET_KEY from the environment and support rotation

### DIFF
--- a/canvas_gamification/settings.py
+++ b/canvas_gamification/settings.py
@@ -27,15 +27,28 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "=cv^=w$b8iw4q5!ti#j)mxwujw24o)_d*og7($erv@4t5=3z7*"
-
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.environ.get("DEBUG", "true") == "true"
 HEROKU = False
 
 if DEBUG:
     read_env(os.path.join(BASE_DIR, "env", "gamification.dev.env"))
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# Required from the environment in production: an unset key must stop the
+# process rather than silently fall back to a value committed to this
+# repository, which would be public and therefore no secret at all.
+if DEBUG:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-dev-key-not-for-production")
+else:
+    SECRET_KEY = os.environ["SECRET_KEY"]
+
+# Whitespace-separated previous keys. Signatures made with them still verify,
+# so rotating SECRET_KEY does not log everyone out or invalidate password-reset
+# links that are already in flight. Drop an old key once it is older than both
+# SESSION_COOKIE_AGE (14 days) and PASSWORD_RESET_TIMEOUT (3 days) -- while it
+# is listed, anything signed with it is still accepted.
+SECRET_KEY_FALLBACKS = os.environ.get("SECRET_KEY_FALLBACKS", "").split()
 
 if HEROKU:
     ALLOWED_HOSTS = ["canvas-gamification.herokuapp.com"]

--- a/env/gamification.sample.env
+++ b/env/gamification.sample.env
@@ -17,4 +17,12 @@ RECAPTCHA_URL=https://www.google.com/recaptcha/api/siteverify
 
 COMMUNITY_JWT_PRIVATE_KEY=change-me-community-jwt-private-key
 
+# Required in production -- the app will not start without it.
+# Generate with:  python3 -c 'import secrets; print(secrets.token_urlsafe(64))'
+SECRET_KEY=change-me-django-secret-key
+# Whitespace-separated previous SECRET_KEYs, so rotating does not log everyone
+# out or break password-reset links already sent. Remove an old key after two
+# weeks; until then, anything signed with it is still accepted.
+SECRET_KEY_FALLBACKS=
+
 SENTRY_DSN=

--- a/env/test.env
+++ b/env/test.env
@@ -17,4 +17,6 @@ RECAPTCHA_URL=https://www.google.com/recaptcha/api/siteverify
 
 COMMUNITY_JWT_PRIVATE_KEY=test-community-jwt-private-key-not-for-production
 
+SECRET_KEY=test-secret-key-not-for-production
+
 SENTRY_DSN=

--- a/test/baseline/test_secret_key.py
+++ b/test/baseline/test_secret_key.py
@@ -1,0 +1,129 @@
+"""SECRET_KEY sourcing and rotation.
+
+The key used to live as a literal in settings.py, committed to a public
+repository. It now comes from the environment and is mandatory in production,
+so a deployment cannot quietly run on a published key.
+
+The startup behaviour is exercised by importing the settings in a subprocess:
+settings are read once per process, so DEBUG and SECRET_KEY cannot be
+meaningfully varied with override_settings.
+"""
+
+import os
+import re
+import subprocess
+import sys
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.test import TestCase, override_settings
+
+IMPORT_SETTINGS = "import django; django.setup()"
+PRINT_FALLBACKS = (
+    "import django; django.setup(); from django.conf import settings; print(settings.SECRET_KEY_FALLBACKS)"
+)
+
+
+def read_env_file(path):
+    values = {}
+    with open(path) as f:
+        for line in f:
+            match = re.match(r"\A([A-Za-z_0-9]+)=(.*)\Z", line.strip())
+            if match:
+                values[match.group(1)] = match.group(2)
+    return values
+
+
+def start_django(code=IMPORT_SETTINGS, **overrides):
+    """Import the settings in a clean process, with production-style env vars.
+
+    Anything passed as None is removed from the environment.
+    """
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": str(settings.BASE_DIR),
+        "DJANGO_SETTINGS_MODULE": "canvas_gamification.settings",
+    }
+    env.update(read_env_file(os.path.join(settings.BASE_DIR, "env", "test.env")))
+    for key, value in overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(settings.BASE_DIR),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+class SecretKeySourcingTest(TestCase):
+    def test_production_refuses_to_start_without_a_secret_key(self):
+        result = start_django(SECRET_KEY=None, DEBUG="false")
+        self.assertNotEqual(result.returncode, 0, "settings imported without a SECRET_KEY")
+        self.assertIn("SECRET_KEY", result.stderr)
+
+    def test_production_starts_with_a_secret_key(self):
+        result = start_django(SECRET_KEY="a-perfectly-fine-production-key", DEBUG="false")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_debug_falls_back_to_a_development_key(self):
+        # Local work and `manage.py` one-liners must not require any setup.
+        result = start_django(SECRET_KEY=None, DEBUG="true")
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_the_committed_literal_is_gone(self):
+        with open(os.path.join(settings.BASE_DIR, "canvas_gamification", "settings.py")) as f:
+            source = f.read()
+        self.assertNotIn("=cv^=w$b8iw4q5", source)
+
+    def test_fallbacks_are_split_on_whitespace(self):
+        result = start_django(
+            code=PRINT_FALLBACKS,
+            SECRET_KEY="current",
+            SECRET_KEY_FALLBACKS="older newer",
+            DEBUG="false",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "['older', 'newer']")
+
+    def test_fallbacks_default_to_empty(self):
+        result = start_django(code=PRINT_FALLBACKS, SECRET_KEY="current", SECRET_KEY_FALLBACKS=None, DEBUG="false")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "[]")
+
+
+class SecretKeyRotationTest(TestCase):
+    """The point of the fallbacks: rotating must not break live tokens."""
+
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username="rotation@example.com",
+            email="rotation@example.com",
+            password="an-ordinary-password",
+        )
+        self.old_key = "the-old-secret-key"
+        self.new_key = "the-new-secret-key"
+
+    def make_token(self):
+        with override_settings(SECRET_KEY=self.old_key, SECRET_KEY_FALLBACKS=[]):
+            return PasswordResetTokenGenerator().make_token(self.user)
+
+    def test_token_from_the_old_key_survives_rotation_with_a_fallback(self):
+        token = self.make_token()
+        with override_settings(SECRET_KEY=self.new_key, SECRET_KEY_FALLBACKS=[self.old_key]):
+            self.assertTrue(PasswordResetTokenGenerator().check_token(self.user, token))
+
+    def test_token_from_the_old_key_dies_once_the_fallback_is_removed(self):
+        token = self.make_token()
+        with override_settings(SECRET_KEY=self.new_key, SECRET_KEY_FALLBACKS=[]):
+            self.assertFalse(PasswordResetTokenGenerator().check_token(self.user, token))
+
+    def test_new_tokens_verify_under_the_new_key(self):
+        with override_settings(SECRET_KEY=self.new_key, SECRET_KEY_FALLBACKS=[self.old_key]):
+            token = PasswordResetTokenGenerator().make_token(self.user)
+            self.assertTrue(PasswordResetTokenGenerator().check_token(self.user, token))


### PR DESCRIPTION
`SECRET_KEY` was a literal in `settings.py`, so the production signing key has been public in this repository for its entire history. It now comes from the environment, is mandatory in production, and can be rotated without logging everyone out.

## ⚠️ Read before deploying

**`env/gamification.env` on the server must gain a `SECRET_KEY` before this ships, or the `web` container will not boot.** That is deliberate — see below — but it does mean this PR is not a "merge and forget" change.

Generate one with:

```bash
python3 -c 'import secrets; print(secrets.token_urlsafe(64))'
```

The URL-safe alphabet matters: `#`, `$`, quotes and spaces can be mangled by docker-compose's `env_file` parsing.

**Set `COMMUNITY_JWT_PRIVATE_KEY` explicitly at the same time.** It falls back to `SECRET_KEY` (`settings.py`, added in #404), so rotating one silently re-keys the other if the JWT key was never set.

## Why

Anything derived from `SECRET_KEY` — session cookies, password-reset tokens, account-activation tokens — was forgeable by anyone who read the source. Rotating is overdue regardless of this PR; this just makes rotation possible.

```diff
-SECRET_KEY = "=cv^=w$b8iw4q5!ti#j)mxwujw24o)_d*og7($erv@4t5=3z7*"
+if DEBUG:
+    SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-dev-key-not-for-production")
+else:
+    SECRET_KEY = os.environ["SECRET_KEY"]
```

`os.environ[...]` rather than `.get()` in the production branch is the point: a missing key must stop the process, not silently fall back to a published value. `DEBUG` keeps an obvious throwaway default so local work and one-off `manage.py` commands need no setup.

`SECRET_KEY` also moved below the `read_env()` call, so a value in the dev env file is actually honoured.

## Rotation

```python
SECRET_KEY_FALLBACKS = os.environ.get("SECRET_KEY_FALLBACKS", "").split()
```

Whitespace-separated old keys (Django 4.1+). Signatures made with a listed key still verify, so rotating neither logs every admin out nor invalidates password-reset links already in flight:

```bash
SECRET_KEY=<new>
SECRET_KEY_FALLBACKS=<the old literal>
```

Drop the old entry after about two weeks — that clears both `SESSION_COOKIE_AGE` (14 days) and `PASSWORD_RESET_TIMEOUT` (3 days). **Don't leave it longer than needed: while it is listed, the leaked key still validates signatures.**

DRF auth tokens are unaffected either way — they are random strings in the database, not signed — so Angular users stay logged in through a rotation.

## Env files

- `env/test.env` gains a key: CI runs the suite through `docker-compose.test.yml` with `DEBUG=false`, so without it the whole test job would fail to start.
- `env/gamification.sample.env` documents both settings and the generation command.

## Tests

`test/baseline/test_secret_key.py` — 9 tests. Startup behaviour is checked by importing the settings in a **subprocess**, since settings are read once per process and `DEBUG`/`SECRET_KEY` cannot be varied with `override_settings`:

- production refuses to start without a key, and starts with one
- `DEBUG` falls back to the development key
- the old committed literal is gone from `settings.py`
- fallbacks split on whitespace, and default to `[]`
- **rotation actually works**: a password-reset token minted under the old key still verifies when that key is listed as a fallback, and stops verifying once it is removed

Full suite: **791/791**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
