### PR TITLE
ci: drop the unused GHCR image publishing job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run tests
+      # `compose build` builds the sut service from this repo's Dockerfile
+      # (build: .), so a broken Dockerfile fails CI here, before any test runs.
+      - name: Build image and run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker compose --file docker-compose.test.yml build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,24 +2,13 @@ name: Test
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
     branches:
       - master
-
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
 
   # Run tests for any PRs.
   pull_request:
 
-env:
-  # TODO: Change variable to your image's name.
-  IMAGE_NAME: image
-
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
 
@@ -34,44 +23,3 @@ jobs:
           else
             docker build . --file Dockerfile
           fi
-
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
-  push:
-    # Ensure test job passes before pushing image.
-    needs: test
-
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
-
-      - name: Log into GitHub Container Registry
-      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
-        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Push image to GitHub Container Registry
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
Master CI has been red on every push. The `test` job passes; the `push` job fails.

```
Log into GitHub Container Registry
  Error response from daemon: Get "https://ghcr.io/v2/": denied: denied
  ##[error]Process completed with exit code 1
```

It authenticates with a `CR_PAT` secret that is unset or expired — the workflow still carries the scaffolding TODO for creating it:

```yaml
# TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
```

Nothing consumes the published image. Deployment builds from source on the server through `docker compose`, so master CI has been failing purely for a step whose output nobody uses.

This removes the `push` job, the now-unused `IMAGE_NAME` env var, and the `tags: v*` trigger that existed only to publish tagged releases as images.

## The image is still built, and a broken Dockerfile still fails CI

Worth being explicit, since the removed job contained a `docker build` step: **that build was redundant.** The `test` job runs

```
docker compose --file docker-compose.test.yml build
```

and `docker-compose.test.yml`'s `sut` service is `build: .` — the same Dockerfile, the same context. The removed job simply built it a second time.

Verified rather than assumed: replacing the Dockerfile's base image with a nonexistent one and running that exact compose command exits **1**, so the step fails before any test runs:

```
failed to solve: this-image-does-not-exist:0: failed to resolve source metadata
EXIT CODE WITH BROKEN DOCKERFILE: 1
```

The step is renamed to "Build image and run tests" with a comment, so the build coverage is not invisible to the next reader.

Tests still run on master pushes and on every pull request; the `test` job is otherwise untouched.

If you ever do want images published, the alternative is `secrets.GITHUB_TOKEN` with `permissions: packages: write`, which needs no manually-managed PAT. Not added here since nothing pulls the image today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)